### PR TITLE
Add team, priority labels to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Flags:
 
 ## Metrics
 
-|Name                                         |Type     |Cardinality   |Help
-|----                                         |----     |-----------   |----
-| opsgenie_alerts_created_total                 | counter   | 1            | Returns the total amount of alerts by status.
-| opsgenie_alerts_status_count                 | gauge   | 1            | Returns the actual amount of alerts by status. Can be filtered by status `closed`, `open` or all
-| opsgenie_teams_count                | gauge   | 1            | Returns the actual number of teams of your account
-| opsgenie_users_count                | gauge   | 1            | Returns the actual number of users. Can be filtered by `role`
+| Name                          | Type    | Cardinality | Help                                                                                                |
+| ----------------------------- | ------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| opsgenie_alerts_created_total | counter | 1           | Returns the total amount of alerts by status. Can be filtered by `team` and `priority`.             |
+| opsgenie_alerts_status_count  | gauge   | 1           | Returns the actual amount of alerts by status. Can be filtered by `status`, `team`, and `priority`. |
+| opsgenie_teams_count          | gauge   | 1           | Returns the actual number of teams of your account                                                  |
+| opsgenie_users_count          | gauge   | 1           | Returns the actual number of users. Can be filtered by `role`                                       |
 
 ## Development
 

--- a/opsgenie_test.go
+++ b/opsgenie_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_countAlertsParams_ToQuery(t *testing.T) {
+	testcases := []struct {
+		Name   string
+		Input  countAlertsParams
+		Output string
+	}{
+		{
+			Name:   "default params",
+			Input:  countAlertsParams{},
+			Output: "",
+		},
+		{
+			Name: "status only",
+			Input: countAlertsParams{
+				Status: "open",
+			},
+			Output: "status: open",
+		},
+		{
+			Name: "team only",
+			Input: countAlertsParams{
+				Team: "Everyone",
+			},
+			Output: "teams: Everyone",
+		},
+		{
+			Name: "priority only",
+			Input: countAlertsParams{
+				Priority: "P2",
+			},
+			Output: "priority: P2",
+		},
+		{
+			Name: "status + team",
+			Input: countAlertsParams{
+				Status:   "closed",
+				Team:     "Everyone",
+				Priority: "P3",
+			},
+			Output: "status: open AND teams: Everyone AND priority: P3",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			if actual := testcase.Input.ToQuery(); actual != testcase.Output {
+				t.Errorf("ToQuery() failed: %s != %s", actual, testcase.Output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Adds ability to breakdown opsgenie_alerts_created_total and opsgenie_alerts_status_count by team, priority labels.

- Adds tests to assert opsgenie query is generated with the correct syntax